### PR TITLE
Fix kwargs in LibCloud.Storage

### DIFF
--- a/src/storage.jl
+++ b/src/storage.jl
@@ -73,17 +73,17 @@ const _object_fns = [
 
 for f in union(Set(_storagedriver_fns), Set(_base_driver_fns))
     sf = string(f)
-    @eval @doc LazyHelp(_libcloud_storage_base, "StorageDriver", $sf) $(f)(storage::StorageDriver, args...; kwargs...) = storage.o[$(sf)](args..., kwargs...)
+    @eval @doc LazyHelp(_libcloud_storage_base, "StorageDriver", $sf) $(f)(storage::StorageDriver, args...; kwargs...) = storage.o[$(sf)](args...; kwargs...)
 end
 
 for f in _container_fns
     sf = string(f)
-    @eval @doc LazyHelp(_libcloud_storage_base, "Container", $sf) $(f)(cont::Container, args...; kwargs...) = cont.o[$(sf)](args..., kwargs...)
+    @eval @doc LazyHelp(_libcloud_storage_base, "Container", $sf) $(f)(cont::Container, args...; kwargs...) = cont.o[$(sf)](args...; kwargs...)
 end
 
 for f in _object_fns
     sf = string(f)
-    @eval @doc LazyHelp(_libcloud_storage_base, "Object", $sf) $(f)(obj::Object, args...; kwargs...) = obj.o[$(sf)](args..., kwargs...)
+    @eval @doc LazyHelp(_libcloud_storage_base, "Object", $sf) $(f)(obj::Object, args...; kwargs...) = obj.o[$(sf)](args...; kwargs...)
 end
 
 # Initialize cloud storage


### PR DESCRIPTION
I am passing keyword arguments to the `list_container_objects` function in `LibCloud.Storage`.

Directly calling the storage object with keywords:
```
storage.o[:list_container_objects](cont, ex_prefix="a6531728")
1-element Array{Any,1}:
 <Object: name=a6531728-ba60-11e6-1ba9-478c5c1e04cb, size=4872874, hash=bd6d756fe1109262a1417a16b7ce72ba, provider=Amazon S3 (eu-west-1) ...>
```
however:
```
list_container_objects(storage, cont, ex_prefix="a6531728")
0-element Array{Any,1}
```

The fix may need to be applied elsewhere in the codebase, though since I don't use the other functions at present I'm hesitant to modify them.